### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Cache Cargo registry + build
         uses: actions/cache@v4


### PR DESCRIPTION
- At some point since last PR, the rust installation decided to no long install rustfmt/clippy by default
- Add explicit install for rustfmt, clippy so CI actually works