### PR TITLE
Cargo version 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "rts-alloc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rts-alloc"
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 description = "Shared memory allocator intended for small frequent allocations"
 license-file = "LICENSE"
 repository = "https://github.com/apfitzge/rts-alloc"


### PR DESCRIPTION
bump to 0.1.1 to publish added `unsafe` on `join`